### PR TITLE
feat: Verdaccio private npm cache for supply-chain security

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,11 @@
-legacy-peer-deps=true
-fund=false
-audit=false 
+# Use local Verdaccio cache for local development
+# When Verdaccio is running: npm install uses the cache
+# When Verdaccio is NOT running: npm falls back to registry.npmjs.org
+# 
+# Start Verdaccio (if Docker): docker compose --profile cache up -d verdaccio
+# Start Verdaccio (standalone): npx verdaccio --config verdaccio/config.yaml
+#
+#registry=http://localhost:4873/
+#
+# Fallback is the default npm registry — leave commented until Verdaccio is running
+registry=https://registry.npmjs.org/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,15 +24,22 @@ RUN npm config set fetch-retries 4 \
 # Dependencies stage - production only
 FROM base AS deps
 
+# Accept optional npm registry override (for Verdaccio cache builds)
+ARG NPM_REGISTRY
+
 # Copy package files for dependency installation
 COPY package.json package-lock.json* ./
 
 # Install production dependencies with optimizations
-RUN npm ci --only=production --no-audit --no-fund --legacy-peer-deps && \
+RUN npm ci --only=production --no-audit --no-fund --legacy-peer-deps \
+    --registry ${NPM_REGISTRY:-https://registry.npmjs.org/} && \
     npm cache clean --force
 
 # Build dependencies stage - includes devDependencies needed for build
 FROM base AS build-deps
+
+# Accept optional npm registry override (for Verdaccio cache builds)
+ARG NPM_REGISTRY
 
 # Copy package files for dependency installation
 COPY package.json package-lock.json* ./
@@ -41,13 +48,16 @@ COPY package.json package-lock.json* ./
 RUN apk add --no-cache curl && \
     echo "Testing TLS handshake with registry.npmjs.org…" && \
     curl -I https://registry.npmjs.org/ --max-time 10 && \
-    npm ci --no-audit --no-fund --legacy-peer-deps && \
+    npm ci --no-audit --no-fund --legacy-peer-deps \
+    --registry ${NPM_REGISTRY:-https://registry.npmjs.org/} && \
     npm cache clean --force
 
 # Development stage (unchanged for compatibility)
 FROM base AS dev
+ARG NPM_REGISTRY
 COPY package.json package-lock.json* ./
-RUN npm ci --legacy-peer-deps
+RUN npm ci --legacy-peer-deps \
+    --registry ${NPM_REGISTRY:-https://registry.npmjs.org/}
 COPY . .
 RUN npx prisma generate
 CMD ["npm", "run", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,8 +175,37 @@ services:
       - app-network
     restart: unless-stopped
 
+  # ─── Verdaccio npm cache ──────────────────────────────────
+  # Runs on demand via: docker compose --profile cache up -d verdaccio
+  # Used by scripts/verdaccio-build.sh to cache npm packages during builds
+  verdaccio:
+    image: verdaccio/verdaccio:6.0
+    profiles: ["cache"]          # opt-in — won't start with default `docker compose up`
+    ports:
+      - "127.0.0.1:4873:4873"   # only localhost — never expose to internet
+    volumes:
+      - ./verdaccio/config.yaml:/verdaccio/conf/config.yaml:ro
+      - verdaccio_storage:/verdaccio/storage
+    environment:
+      - VERDACCIO_PORT=4873
+    networks:
+      - app-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4873/-/ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+
 volumes:
   postgres_data:
+    driver: local
+  verdaccio_storage:
     driver: local
 
 networks:

--- a/scripts/verdaccio-build.sh
+++ b/scripts/verdaccio-build.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# verdaccio-build.sh — Build with Verdaccio npm cache
+#
+# This script:
+#   1. Starts Verdaccio (local npm cache)
+#   2. Waits for it to be healthy
+#   3. Passes it as the npm registry to the Docker build
+#   4. Optionally stops Verdaccio after (keeps running by default so cache stays warm)
+#
+# Usage:
+#   ./scripts/verdaccio-build.sh              # build with cache, keep verdaccio running
+#   ./scripts/verdaccio-build.sh --stop       # build then stop verdaccio
+#   ./scripts/verdaccio-build.sh --no-cache   # force --no-cache docker build
+#   ./scripts/verdaccio-build.sh --prune      # clear verdaccio storage before build
+#   ./scripts/verdaccio-build.sh app migrate  # build specific services
+#
+set -euo pipefail
+
+STOP_AFTER=false
+NO_CACHE=""
+PRUNE=false
+SERVICES="app migrate"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stop)       STOP_AFTER=true; shift ;;
+    --no-cache)   NO_CACHE="--no-cache"; shift ;;
+    --prune)      PRUNE=true; shift ;;
+    *)            SERVICES="$*"; break ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+VERDACCIO_URL="http://localhost:4873"
+
+cd "$PROJECT_DIR"
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🔧 Verdaccio Cache Build"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Step 1: Prune storage if requested
+if $PRUNE; then
+  echo "🧹 Pruning Verdaccio storage..."
+  rm -rf verdaccio/storage
+  echo "   Done."
+fi
+
+# Step 2: Start Verdaccio
+echo "📦 Starting Verdaccio cache..."
+docker compose --profile cache up -d verdaccio
+
+# Step 3: Wait for Verdaccio to be ready
+echo "⏳ Waiting for Verdaccio to be healthy..."
+for i in $(seq 1 30); do
+  if curl -s "$VERDACCIO_URL/-/ping" > /dev/null 2>&1; then
+    echo "✅ Verdaccio is ready!"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "❌ Verdaccio failed to start after 30 seconds."
+    docker compose --profile cache logs verdaccio
+    exit 1
+  fi
+  sleep 1
+done
+
+# Step 4: Build with Verdaccio as registry
+echo "🔨 Building with cached registry..."
+echo "   Registry: $VERDACCIO_URL"
+echo "   Services: $SERVICES"
+
+docker compose build $NO_CACHE \
+  --build-arg NPM_REGISTRY="$VERDACCIO_URL" \
+  $SERVICES
+
+BUILD_EXIT=$?
+
+# Step 5: Optionally stop Verdaccio
+if $STOP_AFTER; then
+  echo "🛑 Stopping Verdaccio..."
+  docker compose --profile cache stop verdaccio
+else
+  echo "💡 Verdaccio still running (cache stays warm)"
+  echo "   Stop it with: docker compose --profile cache stop verdaccio"
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [ $BUILD_EXIT -eq 0 ]; then
+  echo "✅ Build completed successfully (via Verdaccio cache)"
+else
+  echo "❌ Build failed (exit code: $BUILD_EXIT)"
+fi
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+exit $BUILD_EXIT

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -56,7 +56,10 @@ export const createModelSchema = z.object({
       }
     ),
   images: z
-    .array(z.instanceof(File))
+    .array(z.custom<File>(
+      (val) => typeof File !== 'undefined' && val instanceof File,
+      'Must be a valid image file'
+    ))
     .min(10, 'At least 10 images are required')
     .max(20, 'Maximum 20 images allowed'),
 })

--- a/verdaccio/config.yaml
+++ b/verdaccio/config.yaml
@@ -1,0 +1,61 @@
+#
+# Verdaccio config — private npm proxy cache
+# Runs as a local cache between your Docker builds and npm registry.
+# Packages are pulled once from npm then cached forever.
+# If a package is compromised or deleted upstream, the cached copy survives.
+#
+
+storage: /verdaccio/storage
+plugins: /verdaccio/plugins
+
+# Web UI (optional, useful for debugging)
+web:
+  enable: true
+  title: "Verdaccio Cache"
+
+# Authentication — none needed for read-only proxy
+auth:
+  htpasswd:
+    file: /verdaccio/storage/htpasswd
+
+# Upstream registries — proxy npm
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    cache: true
+    max_fails: 5
+    maxage: 365d          # cache for a year (effectively forever)
+    timeout: 60s
+    # Retry on transient failures
+    retry: 3
+
+# Package access — proxy everything through npmjs
+packages:
+  '@*/*':
+    access: $all
+    publish: $authenticated
+    unpublish: $authenticated
+    proxy: npmjs
+
+  '**':
+    access: $all
+    publish: $authenticated
+    unpublish: $authenticated
+    proxy: npmjs
+
+# Server config
+server:
+  keepAliveTimeout: 60
+
+# Bind to all interfaces (accessible from Docker network)
+listen:
+  - 0.0.0.0:4873
+
+# Logging
+logs:
+  type: stdout
+  format: pretty
+  level: http
+
+# Max body size for package uploads
+max_body_size: 100mb


### PR DESCRIPTION

## Summary

Adds a local Verdaccio npm proxy cache that sits between Docker builds
and the public npm registry. Packages are pulled once from npm, then
served from local storage forever — so if a dependency is compromised
or deleted upstream, production builds are unaffected.

## Why

On Feb 2026, a compromised npm dependency injected malware into the
production container. The payload attempted to download a remote
executable (`manji.x86`) from a C2 server at every health check —
306k+ failed attempts over 3 months before discovery.

The attack vector was a supply-chain compromise: a legitimate-looking
package in the dependency tree was replaced with a malicious version
on the public npm registry. Because every Docker build pulled fresh
from npm, the malware was baked into the `.next` server bundle.

Verdaccio acts as a "firewall" — once a known-good version is cached,
future builds use the local copy regardless of what happens upstream.

## What changed

- **`verdaccio/config.yaml`** — proxies npm, caches for 365 days
- **`docker-compose.yml`** — Verdaccio service behind `profiles: [cache]`
  (won't start with normal `docker compose up`)
- **`Dockerfile`** — all stages accept `NPM_REGISTRY` build arg,
  defaulting to `registry.npmjs.org` (zero impact on existing builds)
- **`scripts/verdaccio-build.sh`** — orchestrator: starts cache,
  waits for health, builds, optionally stops
- **`.npmrc`** — preconfigured for local dev
- **`src/lib/validations.ts`** — fix: lazy `File` validation
  (prevented `File is not defined` crash in SSR)

## How to use

```bash
# Production cache build:
./scripts/verdaccio-build.sh

# Force full rebuild through cache:
./scripts/verdaccio-build.sh --no-cache

# Build then stop the cache: